### PR TITLE
move artifacts scripts into main branch

### DIFF
--- a/artifacts_scripts/Project.toml
+++ b/artifacts_scripts/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"

--- a/artifacts_scripts/common.jl
+++ b/artifacts_scripts/common.jl
@@ -1,0 +1,30 @@
+using Pkg: Artifacts
+using Downloads
+using SHA
+using ZipArchives
+using DelimitedFiles
+
+function sha256sum(tarball_path)
+    return open(tarball_path, "r") do io
+        return bytes2hex(sha256(io))
+    end
+end
+downloads_dir = joinpath(@__DIR__, "..", "downloads")
+isdir(downloads_dir) || mkdir(downloads_dir)
+
+assets_dir = joinpath(@__DIR__, "..", "assets")
+isdir(assets_dir) || mkdir(assets_dir)
+
+artifact_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
+
+release_root_url = "https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl/releases/download/artifacts_releases/"
+
+function parseline(str::AbstractString, ::Type{T} = Float64) where T
+    cleaned = replace(strip(str), r" +" => ' ')
+    return map(x -> parse(T, x), split(cleaned, ' '))
+end
+
+function parsematrix(file::AbstractString, ::Type{T} = Float64) where T
+    return stack(s -> parseline(s, T), eachline(file)) |> permutedims
+end
+

--- a/artifacts_scripts/p1511.jl
+++ b/artifacts_scripts/p1511.jl
@@ -1,0 +1,89 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p1511_artifact()
+    artifact_name = "p1511"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the files applicable for ITU-R P.1511-3 recommendation
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.1511-3-202408-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p1511_data.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.1511-3 recommendation from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains data for the ITU-R P.1511-3 recommendation.")
+                println(io)
+                println(io, "It was automatically generated from the TXT/dat files of the ITU-R P.1511-3 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io)
+                println(io, "It also still contains the readmes originally present in the ITU data")
+                println(io)
+                println(io, "The matrices stored in this artifact contains values in meters and have slightly different grids but with a fixed resolution of 1/12 degress in both lat and lon.")
+                println(io, "For both files/variables, the grid _wraps_ around the edges of the grid to simplify the bi-cubic interpolation.")
+                println(io, "- For the TOPO.dat file, the grid goes from -90.125 to 90.125 degrees in latitude and from -180.125 to 180.125 degrees in longitude. This results in a matrix of 2164 x 4324 elements.")
+                println(io, "- For the EGM2008.txt file, the grid goes from -(90 + 2/12) to (90 + 2/12) degrees in latitude and from -(180 + 2/12) to (180 + 2/12)  degrees in longitude. This results in a matrix of 2165 x 4325 elements.")
+                println(io)
+                println(io, "The data is stored with negative latitude/longitude in the upper left corner and positive latitude/longitude in the lower right corner. This is the opposite of how the raw data is stored in the text files downloaded directly from the ITU database.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p1511.jl")
+            end
+
+            archive = ZipReader(read(zip_path))
+            for name in zip_names(archive)
+                if endswith(name, "zip")
+                    @info "Processing zip file $name"
+                    # We have to recursively process this zip and extract it in a subfolder
+                    subarchive = ZipReader(zip_readentry(archive, name))
+                    for subname in zip_names(subarchive)
+                        if subname in ("TOPO.dat", "EGM2008.txt")
+                            @info "Converting file $subname"
+                            matsize = subname === "TOPO.dat" ? (2164, 4324) : (2165, 4325)
+                            filecontent = zip_readentry(subarchive, subname)
+                            binfile = joinpath(artifact_folder, replace(subname, r"txt|dat" => "bin"))
+                            data = stack(parseline, eachline(IOBuffer(filecontent))) |> permutedims # The data is permuted because stack creates a transposed matrix in this case. 
+                            reverse!(data; dims=1) # We also need to reverse the latitude (U/D) because the data has the max (positive) lat at the top while for indexing we want the opposite.
+                            size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $subname")
+                            open(binfile, "w") do io
+                                write(io, data)
+                            end
+                        else
+                            @info "Copying file $subname"
+                            open(joinpath(artifact_folder, subname), "w") do io
+                                write(io, zip_readentry(subarchive, subname))
+                            end
+                        end
+                    end
+                else
+                    # We don't know what to do with this file
+                    error("Unknown file type: $name")
+                end
+            end
+        end
+
+    end
+
+
+    asset_name = "p1511_data.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p1511_artifact()

--- a/artifacts_scripts/p2145.jl
+++ b/artifacts_scripts/p2145.jl
@@ -1,0 +1,87 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p2145_annual_artifact()
+    artifact_name = "p2145_annual"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the Part 1 of the ITU-R P.2145-0 recommendation (Annual Data)
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.2145Part01-0-202208-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p2145_2022_Part1_annual.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.2145-0 Part 1 (Annual Data) from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+            latres = 0.25
+            lonres = 0.25
+
+            latrange = range(-90, 90, step=latres)
+            lonrange = range(0, 360, step=lonres)
+
+            matsize = (length(latrange), length(lonrange))
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains data for the ITU-R P.2145-0 recommendation (Annual Data) directly in binary format.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of the Part 1 annex of the ITU-R P.2145-0 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io, "The matrices stored into each of the binary files corresponds to a lat/lon grid with $(latres)° x $(lonres)° resolution and have a size of $(matsize) elements.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p2145.jl")
+            end
+
+            archive = ZipReader(read(zip_path))
+            for name in zip_names(archive)
+                if endswith(lowercase(name), "txt")
+                    # We copy this to the artifact folder
+                    open(joinpath(artifact_folder, name), "w") do io
+                        write(io, zip_readentry(archive, name))
+                    end
+                elseif endswith(name, "zip")
+                    @info "Processing zip file $name"
+                    # We have to recursively process this zip and extract it in a subfolder
+                    foldername = joinpath(artifact_folder, replace(name, ".zip" => ""))
+                    isdir(foldername) || mkdir(foldername)
+                    subarchive = ZipReader(zip_readentry(archive, name))
+                    for subname in zip_names(subarchive)
+                        @info "Converting file $subname"
+                        endswith(subname, "TXT") || error("Unexpected file type: $subname")
+                        filecontent = zip_readentry(subarchive, subname)
+                        binfile = joinpath(foldername, replace(subname, ".TXT" => ".bin"))
+                        data = readdlm(filecontent, ' ')
+                        size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $subname")
+                        open(binfile, "w") do io
+                            write(io, data)
+                        end
+                    end
+                else
+                    # We don't know what to do with this file
+                    error("Unknown file type: $name")
+                end
+            end
+        end
+
+    end
+
+
+    asset_name = "p2145_2022_Part1_annual.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p2145_annual_artifact()

--- a/artifacts_scripts/p453_nwet_annual.jl
+++ b/artifacts_scripts/p453_nwet_annual.jl
@@ -1,0 +1,81 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p453_nwet_annual_artifact()
+    artifact_name = "p453_nwet_annual"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the components of the ITU-R P.453-14 recommendation
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.453-14-201908-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p453_components.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.453-14 components from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+            latres = 0.75
+            lonres = 0.75
+
+            latrange = range(-90, 90, step=latres)
+            lonrange = range(-180, 180, step=lonres)
+
+            matsize = (length(latrange), length(lonrange))
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains annual Maps for the wet term of surface refractivity to be used for the ITU-R P.453-14 recommendation, directly in binary format.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of components file of the ITU-R P.453-14 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io, "The matrices stored into each of the binary files corresponds to a lat/lon grid with $(latres)°/$(lonres)° corresponding resolution and have a size of $(matsize) elements.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p453_nwet_annual.jl")
+            end
+
+            top = ZipReader(read(zip_path))
+            archive = let 
+                mid = ZipReader(zip_readentry(top, "P.453_NWET_Maps.zip"))
+                bottom = ZipReader(zip_readentry(mid, "P.453_NWET_Maps_Annual.zip"))
+            end
+            # We copy the original docx readme for reference
+            itu_readme = "Readme_P.453.docx"
+            open(joinpath(artifact_folder, "ITU_" * itu_readme), "w") do io
+                write(io, zip_readentry(top, itu_readme))
+            end
+
+
+            for name in zip_names(archive)
+                startswith(name, "NWET") || continue
+                @info "Converting file $name"
+                endswith(name, "TXT") || error("Unexpected file type: $name")
+                filecontent = zip_readentry(archive, name)
+                binfile = joinpath(artifact_folder, replace(name, ".TXT" => ".bin"))
+                data = readdlm(filecontent, ' ')
+                size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $name")
+                open(binfile, "w") do io
+                    write(io, data)
+                end
+            end
+        end
+    end
+
+
+    asset_name = "p453_nwet_annual.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p453_nwet_annual_artifact()

--- a/artifacts_scripts/p676.jl
+++ b/artifacts_scripts/p676.jl
@@ -1,0 +1,78 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p676_artifact()
+    artifact_name = "p676"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            part1_url = "https://www.itu.int/dms_pub/itu-r/oth/11/01/R11010000020001TXTM.txt"
+            part2_url = "https://www.itu.int/dms_pub/itu-r/oth/11/01/R11010000020002TXTM.txt"
+
+            part1_txt = joinpath(artifact_folder, "R11010000020001TXTM.txt")
+            part2_txt = joinpath(artifact_folder, "R11010000020002TXTM.txt")
+
+            Downloads.download(part1_url, part1_txt)
+            Downloads.download(part2_url, part2_txt)
+
+            fvrange = range(1, 350; step = 0.5) |> collect
+            forange = let 
+                v = copy(fvrange)
+                idx = searchsortedfirst(v, 118.75)
+                insert!(v, idx, 118.75)
+                v
+            end
+
+            parts = [
+                (; file = part1_txt, name = "Part1", frange = forange),
+                (; file = part2_txt, name = "Part2", frange = fvrange)
+            ]
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains data for the ITU-R P.676-13 recommendation.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of the ITU-R P.676-13 recommendation available at the following URL:")
+                println(io, "https://www.itu.int/oth/R1101000002/en")
+                println(io)
+                println(io, "This artifact contains the raw txt data as well as the processed binary data obtained by parsing the txt files")
+                println(io)
+                println(io, "For both Part1 and Part2, the data is stored as a n x 5 column matrix where the columns are:")
+                println(io, "1. Frequency in MHz")
+                println(io, "2. aₒ (or aᵥ for Part 2)")
+                println(io, "3. bₒ (or bᵥ for Part 2)")
+                println(io, "4. cₒ (or cᵥ for Part 2)")
+                println(io, "5. dₒ (or dᵥ for Part 2)")
+                println(io)
+                println(io, "For both parts, the input frequency goes from 1 MHz to 350 MHz in steps of 0.5 MHz. For the Part 1, an additional line at 118.75 MHz is added, making the size different between Part1 and Part2 by 1")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p676.jl")
+            end
+
+            for part in parts
+                @info "Processing $(part.name) raw file ($(basename(part.file)))"
+                data = parsematrix(part.file)
+                binfile = joinpath(artifact_folder, part.name * ".bin")
+                open(binfile, "w") do io
+                    write(io, data)
+                end
+            end
+        end
+    end
+
+
+    asset_name = "p676_data.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p676_artifact()

--- a/artifacts_scripts/p837_R001.jl
+++ b/artifacts_scripts/p837_R001.jl
@@ -1,0 +1,79 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p837_R001_artifact()
+    artifact_name = "p837_R001"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the components of the ITU-R P.837-7 recommendation
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.837-7-201706-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p837_R001.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.837-7 from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+            latres = 0.125
+            lonres = 0.125
+
+            latrange = range(-90, 90, step=latres)
+            lonrange = range(-180, 180, step=lonres)
+
+            matsize = (length(latrange), length(lonrange))
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains Maps for the rainfall rate exceeded 0.01% of the time for the ITU-R P.837-7 recommendation, directly in binary format.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of the ITU-R P.837-7 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io, "The matrices stored into each of the binary files corresponds to a lat/lon grid with $(latres)°/$(lonres)° corresponding resolution and have a size of $(matsize) elements.")
+                println(io, "The top-left corner has negative latitude and longitude.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p837_r001.jl")
+            end
+
+            top = ZipReader(read(zip_path))
+            archive = let 
+                mid = ZipReader(zip_readentry(top, "R-REC-P.837-7-Maps.zip"))
+                bottom = ZipReader(zip_readentry(mid, "P.837_R001_Maps.zip"))
+            end
+            # We copy the original docx readme for reference
+            itu_readme = "Readme_P.837_R001.docx"
+            open(joinpath(artifact_folder, "ITU_" * itu_readme), "w") do io
+                write(io, zip_readentry(archive, itu_readme))
+            end
+
+
+            name = "R001.TXT"
+            @info "Converting file $name"
+            filecontent = zip_readentry(archive, name)
+            binfile = joinpath(artifact_folder, replace(name, ".TXT" => ".bin"))
+            data = readdlm(filecontent, ' ')
+            size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $name")
+            open(binfile, "w") do io
+                write(io, data)
+            end
+        end
+    end
+
+
+    asset_name = "p837_R001.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p837_R001_artifact()

--- a/artifacts_scripts/p839.jl
+++ b/artifacts_scripts/p839.jl
@@ -1,0 +1,76 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p839_artifact()
+    artifact_name = "p839"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+    
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the components of the ITU-R P.839-4 recommendation
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.839-4-201309-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p839.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.839-4 from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+            latres = 1.5
+            lonres = 1.5
+
+            latrange = range(-90, 90, step=latres)
+            lonrange = range(-180, 180, step=lonres)
+
+            matsize = (length(latrange), length(lonrange))
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains Maps for the mean annual isotherm height above mean sea level, for use in the ITU-R P.839-4 recommendation, directly in binary format.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of the ITU-R P.839-4 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io, "The matrices stored into each of the binary files corresponds to a lat/lon grid with $(latres)°/$(lonres)° corresponding resolution and have a size of $(matsize) elements.")
+                println(io, "The top-left corner has negative latitude and longitude.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p837_r001.jl")
+            end
+
+            archive = ZipReader(read(zip_path))
+
+            name = "h0.txt"
+            @info "Converting file $name"
+            filecontent = zip_readentry(archive, name)
+            binfile = joinpath(artifact_folder, replace(name, ".txt" => ".bin"))
+            data = readdlm(filecontent, '\t')
+            # We have to permute over lat as we want negative latitude at the top
+            data = reverse(data; dims=1)
+            # We have the raw matrix that goes from 0 to 360 lon, but we want it from -180 to 180
+            nlon = last(matsize)
+            n180 = nlon ÷ 2 # Number of indices from 0 to 180 (excluded)
+            new_idxs = [n180+1:nlon; 2:n180+1]
+            data = data[:, new_idxs]
+            size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $name")
+            open(binfile, "w") do io
+                write(io, data)
+            end
+        end
+    end
+
+
+    asset_name = "p839.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p839_artifact()

--- a/artifacts_scripts/p840.jl
+++ b/artifacts_scripts/p840.jl
@@ -1,0 +1,75 @@
+include(joinpath(@__DIR__, "common.jl"))
+
+function create_p840_annual_artifact()
+    artifact_name = "p840_annual"
+    _artifact_hash = Artifacts.artifact_hash(artifact_name, artifact_toml)
+
+    if isnothing(_artifact_hash) || !Artifacts.artifact_exists(_artifact_hash)
+        _artifact_hash = Artifacts.create_artifact() do artifact_folder
+            # This is the URL for direct download of the zip file containing the Part 1 of the ITU-R P.840-9 recommendation (Annual Data)
+            url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.840Part01-0-202308-I!!ZIP-E.zip"
+
+            zip_path = joinpath(downloads_dir, "p840_2023_Part1_annual.zip")
+            if !isfile(zip_path)
+                @info "Downloading raw zip file for ITU-R P.840-9 Part 1 (Annual Data) from ITU Database"
+                Downloads.download(url, zip_path)
+                @info "Download completed"
+            end
+
+
+            latres = 0.25
+            lonres = 0.25
+
+            latrange = range(-90, 90, step=latres)
+            lonrange = range(0, 360, step=lonres)
+
+            matsize = (length(latrange), length(lonrange))
+
+            # Add a README
+            open(joinpath(artifact_folder, "README"), "w") do io
+                println(io, "This folder contains data for the ITU-R P.840-9 recommendation (Annual Data of Integrated Liquid Water Content) directly in binary format.")
+                println(io)
+                println(io, "It was automatically generated from the TXT files of the Part 1 annex of the ITU-R P.840-9 recommendation available at the following URL:")
+                println(io)
+                println(io, url)
+                println(io, "The matrices stored into each of the binary files corresponds to a lat/lon grid with $(latres)° x $(lonres)° resolution and have a size of $(matsize) elements.")
+                println(io)
+                println(io, "This artifact was automatically generated using the script at the following URL:")
+                println(io, "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/blob/ITU_artifacts/scripts/p840.jl")
+            end
+
+            archive = ZipReader(read(zip_path))
+            for name in zip_names(archive)
+                endswith(lowercase(name), "txt") || throw(ArgumentError("Unexpected file type: $name"))
+                @info "converting file $name"
+                filecontent = zip_readentry(archive, name)
+                binfile = joinpath(artifact_folder, replace(name, ".TXT" => ".bin"))
+                data = readdlm(filecontent, ' ')
+                size(data) == matsize || error("Unexpected size: $(size(data)) instead of $matsize for file $name")
+                open(binfile, "w") do io
+                    write(io, data)
+                end
+            end
+
+            # We also add the original ITU Readme which is stored in a separate url (Part 15)
+            readme_url = "https://www.itu.int/dms_pubrec/itu-r/rec/p/R-REC-P.840Part15-0-202308-I!!MSW-E.docx"
+            itu_readme_path = joinpath(artifact_folder, "ITU_README.docx")
+            Downloads.download(readme_url, itu_readme_path)
+        end
+    end
+
+
+    asset_name = "p840_2023_Part1_annual.tar.gz"
+    tarball_path = joinpath(assets_dir, asset_name)
+    tarball_sha = if !isfile(tarball_path)
+        @info "Creating the artifact tarball"
+        Artifacts.archive_artifact(_artifact_hash, tarball_path)
+    else
+        sha256sum(tarball_path)
+    end
+    release_url = release_root_url * asset_name
+    @info "Updating the Artifacts.toml file"
+    Artifacts.bind_artifact!(artifact_toml, artifact_name, _artifact_hash; force=true, download_info=[(release_url, tarball_sha)])
+end
+
+create_p840_annual_artifact()


### PR DESCRIPTION
This PR brings back the scripts for automatically generating artifacts releases into the main branch instead of a separate one