### PR TITLE
Add handling of p > 50 and p < 0.001 in `attenuations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the changelog for the ItuRPropagation package. It follows the
 
 ## Unreleased
 
+## 1.0.1 - 2025-06-10
+
+### Added
+- Added handling of `p > 50` and `p < 0.001` within the `attenuations` function. Current behavior is to _cap_ outage to a lower value of `0.001` and to return `0.0` for each attenuations when `p > 50`. This behavior can be changed via keyword arguments. Check extended help of `attenuations` for details.
+
 ## 1.0.0 - 2025-06-09
 
 First release of `ITUPropagationModels`, see https://github.com/JuliaSatcomFramework/ItuRPropagation.jl for more insights on PRs and changes on the original repository before the package names was changed.

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITUPropagationModels"
 uuid = "17778021-2b2c-4ecf-610a-391273688f7f"
 authors = ["Alberto Mengali <disberd@gmail.com>", "Hillary Kchao <hillary.kchao@gmail.com>"]
 repo = "https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docs Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliasatcomframework.github.io/ITUPropagationModels.jl/stable)
 [![Docs Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliasatcomframework.github.io/ITUPropagationModels.jl/dev)
 [![Build Status](https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/JuliaSatcomFramework/ITUPropagationModels.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaSatcomFramework/ITUPropagationModels.jl)
+[![codecov](https://codecov.io/gh/JuliaSatcomFramework/ITUPropagationModels.jl/graph/badge.svg?token=JN2HTUAMqd)](https://codecov.io/gh/JuliaSatcomFramework/ITUPropagationModels.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 A Julia implementation of some of the ITU-Recommendations for space links covering cloud, gaseous, rain, and scintillation attenuations.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ Pkg.add(url="https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl")
 
 ## Basic Usage
 
-```julia
+```@example
 using ITUPropagationModels
 
 # Calculate atmospheric attenuation for a satellite link
@@ -21,9 +21,40 @@ elevation = 30.0       # degrees
 probability = 0.01     # % exceedance
 
 # Get all atmospheric attenuations, assume 1m diameter (only used for scintillation attenuation)
-result = attenuations(latlon, frequency, elevation, probability; D = 1)
+attenuations(latlon, frequency, elevation, probability; D = 1)
+```
 
-println("Total attenuation: $(result.total) dB")
+## Custom location types
+It is possible to use the various functions of this package on custom types representing locations on earth by defining an appropriate method for `Base.convert` as shown in the example below.
+
+Additionally, in case your custom type also contains altitude information, it is possible to provide this information to the package function by adding a custom method to the following function
+```@docs
+ITUPropagationModels.altitude_from_location
+```
+
+Here is an example of defining a custom type and making it compatible with the functions from this package:
+
+```@example
+using ITUPropagationModels
+
+# We create a custom struct that also stores location (in m) and lat/lon in radians
+struct LLA
+    lat::Float64
+    lon::Float64
+    alt::Float64
+end
+# Define a convert method to convert to LatLon
+Base.convert(::Type{LatLon}, lla::LLA) = LatLon(lla.lat |> rad2deg, lla.lon |> rad2deg)
+# Define a method to extract the altitude from the custom type, remembering the returned altitude MUST be in km
+ITUPropagationModels.altitude_from_location(lla::LLA) = lla.alt / 1e3
+
+# We test with our custom instance of a type
+lla = LLA(deg2rad(30), deg2rad(45), 1200)
+
+custom = attenuations(lla, 30, 20, .5; D = 1)
+equivalent = attenuations(LatLon(30, 45), 30, 20, .5; D = 1, alt = 1.2)
+println(custom)
+println(equivalent)
 ```
 
 ## Documentation


### PR DESCRIPTION
This PR adds handling of `p > 50` and `p < 0.001` within the `attenuations` function. Current behavior is to _cap_ outage to a lower value of `0.001` and to return `0.0` for each attenuations when `p > 50`. This behavior can be changed via keyword arguments. Check extended help of `attenuations` for details.