### PR TITLE
add intermediate terms function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file contains the changelog for the ItuRPropagation package. It follows the
 
 ## Unreleased
 
+## 1.0.3 - 2025-10-03
+
+### Added
+- Added `attenuations_intermediate_terms` function to compute the intermediate terms for the `attenuations` function that only depend on the location and frequency.
+
 ## 1.0.2 - 2025-10-03
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITUPropagationModels"
 uuid = "17778021-2b2c-4ecf-610a-391273688f7f"
 authors = ["Alberto Mengali <disberd@gmail.com>", "Hillary Kchao <hillary.kchao@gmail.com>"]
 repo = "https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl"
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/docs/src/api/main.md
+++ b/docs/src/api/main.md
@@ -9,6 +9,7 @@ The primary interface for calculating atmospheric attenuations.
 
 ```@docs
 attenuations
+attenuations_intermediate_terms
 ```
 
 

--- a/src/ITUPropagationModels.jl
+++ b/src/ITUPropagationModels.jl
@@ -41,6 +41,9 @@ include("iturP676.jl")
 
 include("iturP618.jl")
 
+include("helpers.jl")
+export attenuations_intermediate_terms
+
 using .ItuRP618: attenuations
 
 #endregion include

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -3,7 +3,7 @@
 
 This function computes all the intermediate terms that can speed up the computation of the P618 attenuations and that only depend on the location (i.e. Latitude and Longitude) and the frequency.
 
-This function is mostly used to simplify speeding up computation by computing once and then storing the terms that do not change for a fixed location.
+This function is useful when the troposheri attenuations (from P618) need to be computed multiple times for the same location and frequency as saving this terms and using them by passing them to the `attenuations` function is more than twice as fast.
 
 ## Arguments
 - `latlon`: Object specifying the latitude and longitude of the location of interest, must be an object that can be converted to an instance of `ITUPropagationModels.LatLon`

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,0 +1,44 @@
+"""
+    attenuations_intermediate_terms(latlon, f; kwargs...)
+
+This function computes all the intermediate terms that can speed up the computation of the P618 attenuations and that only depend on the location (i.e. Latitude and Longitude) and the frequency.
+
+This function is mostly used to simplify speeding up computation by computing once and then storing the terms that do not change for a fixed location.
+
+## Arguments
+- `latlon`: Object specifying the latitude and longitude of the location of interest, must be an object that can be converted to an instance of `ITUPropagationModels.LatLon`
+  - This function can also be called with separate latitude and longitude as first two arguments `lat` and `lon` as per last method in the signatures above.
+- `f`: frequency (GHz)
+
+# Computed terms
+- `Nwet`: Wet term surface refractivity (N-units)
+- `hᵣ`: Rain height [Km] to be used for the computation.
+- `alt`: Altitude [km] of the receiver. Defaults to `ItuRP1511.topographicheight(latlon)`
+- `R001`: Annual rain rate [mm/h] exceeded 0.01% of the time.
+- `γₒ`: Mean surface specific attenuation due to oxygen (dB/km)
+
+!!! note "Overriding some inputs"
+    All of the computed terms can be overridden by providing the intended value as keyword argument with the same name. 
+    
+    For simplicity, the two following terms also accept an alternative name when provided as keyword argument:
+    - `h_r` for `hᵣ` (The Rain Height term [km])
+    - `gamma_oxygen` for `γₒ` (The Mean Surface Specific Attenuation Due to Oxygen term [dB/km])
+"""
+function attenuations_intermediate_terms(latlon, f; Nwet = nothing, h_r = nothing, hᵣ = nothing, alt = nothing, R001 = nothing, gamma_oxygen = nothing, γₒ = nothing)
+    Nwet = @something(Nwet, ItuRP453.wettermsurfacerefractivityannual_50(latlon))
+    hᵣ = @something(hᵣ, h_r, ItuRP839.rainheightannual(latlon)) |> _tokm
+    alt = @something(alt, altitude_from_location(latlon)) |> _tokm
+    R001 = @something(R001, ItuRP837.rainfallrate001(latlon))
+    mean_vals = ItuRP2145.annual_surface_values(latlon; alt)
+    P̄ = mean_vals.P
+    T̄ = mean_vals.T
+    ρ̄ = mean_vals.ρ
+    γₒ = @something γₒ gamma_oxygen let
+        ē = ρ̄ * T̄ / 216.7
+        P̄d = P̄ - ē
+        ItuRP676._gammaoxygen(f, T̄, P̄d, ρ̄).γₒ
+    end
+    return (; Nwet, hᵣ, alt, R001, γₒ)
+end
+
+attenuations_intermediate_terms(lat::Number, lon::Number, f; kwargs...) = attenuations_intermediate_terms(LatLon(lat, lon), f; kwargs...)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -193,3 +193,19 @@ end
 
     @test kwargs_forced == kwargs_normal
 end
+
+@testitem "iturcommon.jl coverage" begin
+    using ITUPropagationModels: EnumHorizontalPolarization, EnumVerticalPolarization, EnumCircularPolarization, tilt_from_polarization, EnumIce
+    # Test tilt_from_polarization
+    @test tilt_from_polarization(EnumHorizontalPolarization) == 0
+    @test tilt_from_polarization(EnumVerticalPolarization) == 90
+    @test tilt_from_polarization(EnumCircularPolarization) == 45
+    @test_throws "Invalid polarization" tilt_from_polarization(EnumIce)
+
+    @test repr(LatLon(10, 20)) == "(10.0, 20.0)"
+end
+
+@testitem "iturP453.jl coverage" begin
+    # Completely random test for coverage. To be improved later with sensible inputs and known outputs
+    @test ItuRP453.radiorefractiveindex(300, 1, 2) > 1
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -182,3 +182,14 @@ end
     @test atts_ll.At ≈ bench_1511alt.At
     @test atts_lla.At ≈ bench_customalt.At
 end
+
+@testitem "Attenuations Intermediate Terms" begin
+    # We try to verify that 
+    intermediate_terms = attenuations_intermediate_terms(10, 20, 30)
+
+    # We verify that the full kwargs terms are the same as the one forced by the intermediate terms
+    kwargs_forced = ItuRP618.attenuations(LatLon(10, 20), 30, 20, 1, Val(true); D = 1, intermediate_terms...).kwargs
+    kwargs_normal = ItuRP618.attenuations(10, 20, 30, 20, 1, Val(true); D = 1).kwargs
+
+    @test kwargs_forced == kwargs_normal
+end


### PR DESCRIPTION
Added `attenuations_intermediate_terms` function to compute the intermediate terms for the `attenuations` function that only depend on the location and frequency.

This function is useful when the troposheri attenuations (from P618) need to be computed multiple times for the same location and frequency as saving this terms and using them by passing them to the `ItuRP618.attenuations` function is more than twice as fast.