### PR TITLE
Improve `attenuations_intermediate_terms` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ This file contains the changelog for the ItuRPropagation package. It follows the
 
 ## Unreleased
 
-## 1.0.3 - 2025-10-03
-
+## 1.1.0 - 2025-10-07
 ### Added
-- Added `attenuations_intermediate_terms` function to compute the intermediate terms for the `attenuations` function that only depend on the location and frequency.
+- Added a new `attenuations_intermediate_terms` function to compute the intermediate terms for the `attenuations` function that only depend on the location of the ground station and, optionally, on the frequency and/or outage probability of the link.
 
 ## 1.0.2 - 2025-10-03
 

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ITUPropagationModels"
 uuid = "17778021-2b2c-4ecf-610a-391273688f7f"
 authors = ["Alberto Mengali <disberd@gmail.com>", "Hillary Kchao <hillary.kchao@gmail.com>"]
 repo = "https://github.com/JuliaSatcomFramework/ITUPropagationModels.jl"
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,6 @@ UnitfulExt = "Unitful"
 
 [compat]
 Artifacts = "1"
-CoordRefSystems = "0.14 - 0.18"
+CoordRefSystems = "0.14 - 0.19"
 Unitful = "1.23.0"
 julia = "1.10"

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,21 +1,27 @@
 """
+    attenuations_intermediate_terms(latlon; kwargs...)
     attenuations_intermediate_terms(latlon, f; kwargs...)
+    attenuations_intermediate_terms(latlon, f, p; kwargs...)
 
-This function computes all the intermediate terms that can speed up the computation of the P618 attenuations and that only depend on the location (i.e. Latitude and Longitude) and the frequency.
+This function computes all the intermediate terms that can speed up the computation of the P618 attenuations.
+The three different methods will produce progressively more intermediate terms (i.e. the outputs of this function) as some terms depend only on location, other also on frequency, and finally others also on the outage probability.
 
-This function is useful when the troposheri attenuations (from P618) need to be computed multiple times for the same location and frequency as saving this terms and using them by passing them to the `attenuations` function is more than twice as fast.
+This function is useful when the troposheric attenuations (from P618) need to be computed multiple times for the same location, frequency and/or outage probability. Saving these terms and passing them as kwargs to the `attenuations` function can lead to up to 10 times faster computation of repeated calls.
 
 ## Arguments
 - `latlon`: Object specifying the latitude and longitude of the location of interest, must be an object that can be converted to an instance of `ITUPropagationModels.LatLon`
   - This function can also be called with separate latitude and longitude as first two arguments `lat` and `lon` as per last method in the signatures above.
-- `f`: frequency (GHz)
+- `f`: frequency (GHz) [Optional]
+- `p`: outage probability (%) [Optional]
 
 # Computed terms
 - `Nwet`: Wet term surface refractivity (N-units)
 - `hᵣ`: Rain height [Km] to be used for the computation.
 - `alt`: Altitude [km] of the receiver. Defaults to `ItuRP1511.topographicheight(latlon)`
 - `R001`: Annual rain rate [mm/h] exceeded 0.01% of the time.
-- `γₒ`: Mean surface specific attenuation due to oxygen (dB/km)
+- `γₒ`: Mean surface specific attenuation due to oxygen (dB/km) [Only returned if `f` is provided as input]
+- `Ag_zenith`: Zenith gaseous attenuation (dB/km) at zenith (90° elevation) [Only returned if `f` and `p` are provided as input]
+- `Ac_zenith`: Zenith cloud attenuation (dB/km) at zenith (90° elevation) [Only returned if `f` and `p` are provided as input]
 
 !!! note "Overriding some inputs"
     All of the computed terms can be overridden by providing the intended value as keyword argument with the same name. 
@@ -23,22 +29,58 @@ This function is useful when the troposheri attenuations (from P618) need to be 
     For simplicity, the two following terms also accept an alternative name when provided as keyword argument:
     - `h_r` for `hᵣ` (The Rain Height term [km])
     - `gamma_oxygen` for `γₒ` (The Mean Surface Specific Attenuation Due to Oxygen term [dB/km])
+
+# Extended Help
+## Example Use
+The following snippet of code can be seen as a way to move some parts of the computation outside of hot loops. The example below will assume to compute attenuations from a specific location, and between the same location and multiple satellites at different elevation angles.
+
+```julia
+using ITUPropagationModels
+gateway = LatLon(52.37, 4.89) # Amsterdam, The Netherlands
+f = 30 # 30 GHz frequency
+
+constant_terms = attenuations_intermediate_terms(gateway, f) # Compute the terms that stay constant for the specific location and assuming 30 GHz frequency
+
+# We now assume that we are at a specific timestep, and we have a instantaneous fading realization corresponding to an outage probability of 1%.
+p = 1 # 1% outage
+current_timestep_terms = attenuations_intermediate_terms(gateway, f, p; constant_terms...) # Compute the terms that stay constant for the specific timestep, taking the terms not depending on the outage as inputs to speed up the additional computation
+
+# We can now use the `current_timestep_terms` to speed up the elevation-dependent computation of attenuations for each specific satellite
+for sat in satellites # This variable is not defined
+    this_sat_attenuations = attenuations(gateway, f, sat.elevation, p; D = 1, current_timestep_terms...)
+end
+```
 """
-function attenuations_intermediate_terms(latlon, f; Nwet = nothing, h_r = nothing, hᵣ = nothing, alt = nothing, R001 = nothing, gamma_oxygen = nothing, γₒ = nothing)
+function attenuations_intermediate_terms(latlon; Nwet = nothing, h_r = nothing, hᵣ = nothing, alt = nothing, R001 = nothing)
     Nwet = @something(Nwet, ItuRP453.wettermsurfacerefractivityannual_50(latlon))
     hᵣ = @something(hᵣ, h_r, ItuRP839.rainheightannual(latlon)) |> _tokm
     alt = @something(alt, altitude_from_location(latlon)) |> _tokm
     R001 = @something(R001, ItuRP837.rainfallrate001(latlon))
-    mean_vals = ItuRP2145.annual_surface_values(latlon; alt)
-    P̄ = mean_vals.P
-    T̄ = mean_vals.T
-    ρ̄ = mean_vals.ρ
+    return (; Nwet, hᵣ, alt, R001)
+end
+
+function attenuations_intermediate_terms(latlon, f; Nwet = nothing, h_r = nothing, hᵣ = nothing, alt = nothing, R001 = nothing, gamma_oxygen = nothing, γₒ = nothing)
+    f = _toghz(f) |> Float64
+    (; alt) = location_based = attenuations_intermediate_terms(latlon; Nwet, h_r, hᵣ, alt, R001)
     γₒ = @something γₒ gamma_oxygen let
+        mean_vals = ItuRP2145.annual_surface_values(latlon; alt)
+        P̄ = mean_vals.P
+        T̄ = mean_vals.T
+        ρ̄ = mean_vals.ρ
         ē = ρ̄ * T̄ / 216.7
         P̄d = P̄ - ē
         ItuRP676._gammaoxygen(f, T̄, P̄d, ρ̄).γₒ
     end
-    return (; Nwet, hᵣ, alt, R001, γₒ)
+    return (; location_based..., γₒ)
 end
 
-attenuations_intermediate_terms(lat::Number, lon::Number, f; kwargs...) = attenuations_intermediate_terms(LatLon(lat, lon), f; kwargs...)
+function attenuations_intermediate_terms(latlon, f, p; Nwet = nothing, h_r = nothing, hᵣ = nothing, alt = nothing, R001 = nothing, gamma_oxygen = nothing, γₒ = nothing, Ac_zenith = nothing, Ag_zenith = nothing)
+    f = _toghz(f) |> Float64
+    (; γₒ, alt) = location_and_frequency_based = attenuations_intermediate_terms(latlon, f; Nwet, h_r, hᵣ, alt, R001, gamma_oxygen, γₒ)
+    p_to_use = max(5, p)
+    Ac_zenith = @something Ac_zenith ItuRP840.cloudattenuation(latlon, f, 90, p_to_use)
+    Ag_zenith = @something Ag_zenith ItuRP676.gaseousattenuation(latlon, f, 90, p_to_use; alt, γₒ)
+    return (; location_and_frequency_based..., Ag_zenith, Ac_zenith)
+end
+
+attenuations_intermediate_terms(lat::Number, lon::Number, args::Vararg{Any, N}; kwargs...) where N = attenuations_intermediate_terms(LatLon(lat, lon), args...; kwargs...)

--- a/src/iturcommon.jl
+++ b/src/iturcommon.jl
@@ -5,6 +5,16 @@ export ItuRVersion
 
 const SUPPRESS_WARNINGS = Ref(false)
 
+"""
+    LatLon(lat, lon)
+Simple structure representing a location on Earth's surface. Used as basic input for most of the functions provided by this package.
+
+# Fields
+- `lat::Float64`: Latitude [degrees]
+- `lon::Float64`: Longitude [degrees]
+
+See also: [`attenuations`](@ref).
+"""
 struct LatLon
     lat::Float64
     lon::Float64

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -185,13 +185,42 @@ end
 
 @testitem "Attenuations Intermediate Terms" begin
     # We try to verify that 
-    intermediate_terms = attenuations_intermediate_terms(10, 20, 30)
+    intermediate_terms = attenuations_intermediate_terms(10, 20, 30, .5)
 
     # We verify that the full kwargs terms are the same as the one forced by the intermediate terms
-    kwargs_forced = ItuRP618.attenuations(LatLon(10, 20), 30, 20, 1, Val(true); D = 1, intermediate_terms...).kwargs
-    kwargs_normal = ItuRP618.attenuations(10, 20, 30, 20, 1, Val(true); D = 1).kwargs
+    kwargs_forced = ItuRP618.attenuations(LatLon(10, 20), 30, 20, .5, Val(true); D = 1, intermediate_terms...).kwargs
+    kwargs_normal = ItuRP618.attenuations(10, 20, 30, 20, .5, Val(true); D = 1).kwargs
 
     @test kwargs_forced == kwargs_normal
+
+    # Here we test the functionality in the example of the docstring for `attenuations_intermediate_terms`
+    gateway = LatLon(52.37, 4.89) # Amsterdam, The Netherlands
+    f = 30 # 30 GHz frequency
+
+    constant_terms = attenuations_intermediate_terms(gateway, f)
+
+    p = 1 # 1% outage
+
+    current_timestep_terms = attenuations_intermediate_terms(gateway, f, p; constant_terms...)
+
+    satellites = [
+        (; elevation = 10),
+        (; elevation = 20),
+        (; elevation = 30),
+        (; elevation = 40),
+        (; elevation = 50),
+        (; elevation = 60),
+        (; elevation = 70),
+        (; elevation = 80),
+        (; elevation = 90),
+    ]
+
+    for sat in satellites
+        this_sat_attenuations = attenuations(gateway, f, sat.elevation, p; D = 1, current_timestep_terms...)
+
+        full_computations = attenuations(gateway, f, sat.elevation, p; D = 1)
+        @test this_sat_attenuations == full_computations
+    end
 end
 
 @testitem "iturcommon.jl coverage" begin


### PR DESCRIPTION
This PR refactor the `attenuations_intermediate_terms` function to know have three main methods, which vary in whether the `frequency` and `outage` are provided as optional second and third argument.

The docstring was also improved and now shows an example use (in the Extended Help)